### PR TITLE
Add v3.4 to classifiers in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ classifiers = [
     "Programming Language :: Python",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 2.7",
+    "Programming Language :: Python :: 3.4",
     "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 2",


### PR DESCRIPTION
Tests were added for it so we support it as much as 3.5/3.6.