### PR TITLE
Switch to io.open() and provide bytes/native/text modes

### DIFF
--- a/filesystems/common.py
+++ b/filesystems/common.py
@@ -125,27 +125,27 @@ class FileMode(object):
     binary = attr.ib()
 
     @read.default
-    def _(self):
+    def read_default(self):
         return self.activity == "r"
 
     @write.default
-    def _(self):
+    def write_default(self):
         return self.activity == "w"
 
     @append.default
-    def _(self):
+    def append_default(self):
         return self.activity == "a"
 
     @text.default
-    def _(self):
+    def text_default(self):
         return self.mode == "t"
 
     @binary.default
-    def _(self):
+    def binary_default(self):
         return self.mode == "b"
 
     @activity.validator
-    def _(self, attribute, value):
+    def activity_validator(self, attribute, value):
         options = ("r", "w", "a")
 
         if value not in options:

--- a/filesystems/common.py
+++ b/filesystems/common.py
@@ -146,7 +146,7 @@ class FileMode(object):
 
     @activity.validator
     def _(self, attribute, value):
-        options = "rwa"
+        options = ("r", "w", "a")
 
         if value not in options:
             raise exceptions.InvalidMode(
@@ -158,7 +158,7 @@ class FileMode(object):
 
     @mode.validator
     def _(self, attribute, value):
-        options = "bt"
+        options = ("b", "t")
 
         if value not in options:
             raise exceptions.InvalidMode(

--- a/filesystems/common.py
+++ b/filesystems/common.py
@@ -112,7 +112,7 @@ def _open_and_read(fs, path):
 
 
 @attr.s(frozen=True)
-class FileMode(object):
+class _FileMode(object):
     activity = attr.ib(default="r")
     mode = attr.ib(
         default='',
@@ -183,4 +183,4 @@ def parse_mode(mode):
         if len(rest) > 0:
             parameters["mode"] = rest
 
-    return FileMode(**parameters)
+    return _FileMode(**parameters)

--- a/filesystems/common.py
+++ b/filesystems/common.py
@@ -172,7 +172,7 @@ class _FileMode(object):
         return self.activity + self.mode
 
 
-def parse_mode(mode):
+def _parse_mode(mode):
     parameters = {}
     first = mode[:1]
     rest = mode[1:]

--- a/filesystems/common.py
+++ b/filesystems/common.py
@@ -172,7 +172,7 @@ class FileMode(object):
         return self.activity + self.mode
 
 
-def normalize_mode(mode):
+def parse_mode(mode):
     parameters = {}
     first = mode[:1]
     rest = mode[1:]

--- a/filesystems/common.py
+++ b/filesystems/common.py
@@ -113,10 +113,10 @@ def _open_and_read(fs, path):
 
 @attr.s(frozen=True)
 class FileMode(object):
-    activity = attr.ib(default='r')
+    activity = attr.ib(default="r")
     mode = attr.ib(
         default='',
-        convert=lambda x: x if x != '' else ('t' if _PY3 else 'b'),
+        convert=lambda x: x if x != "" else ("t" if _PY3 else "b"),
     )
     read = attr.ib()
     write = attr.ib()
@@ -126,31 +126,31 @@ class FileMode(object):
 
     @read.default
     def _(self):
-        return self.activity == 'r'
+        return self.activity == "r"
 
     @write.default
     def _(self):
-        return self.activity == 'w'
+        return self.activity == "w"
 
     @append.default
     def _(self):
-        return self.activity == 'a'
+        return self.activity == "a"
 
     @text.default
     def _(self):
-        return self.mode == 't'
+        return self.mode == "t"
 
     @binary.default
     def _(self):
-        return self.mode == 'b'
+        return self.mode == "b"
 
     @activity.validator
     def _(self, attribute, value):
-        options = 'rwa'
+        options = "rwa"
 
         if value not in options:
             raise exceptions.InvalidMode(
-                'Mode must start with one of {} but found {}'.format(
+                "Mode must start with one of {} but found {}".format(
                     repr(options),
                     repr(value),
                 )
@@ -158,11 +158,11 @@ class FileMode(object):
 
     @mode.validator
     def _(self, attribute, value):
-        options = 'bt'
+        options = "bt"
 
         if value not in options:
             raise exceptions.InvalidMode(
-                'Mode must start with one of {} but found {}'.format(
+                "Mode must start with one of {} but found {}".format(
                     repr(options),
                     repr(value),
                 )
@@ -178,9 +178,9 @@ def normalize_mode(mode):
     rest = mode[1:]
 
     if len(first) > 0:
-        parameters['activity'] = first
+        parameters["activity"] = first
 
         if len(rest) > 0:
-            parameters['mode'] = rest
+            parameters["mode"] = rest
 
     return FileMode(**parameters)

--- a/filesystems/exceptions.py
+++ b/filesystems/exceptions.py
@@ -11,6 +11,13 @@ class InvalidPath(Exception):
     """
 
 
+class InvalidMode(Exception):
+    """
+    The given mode is not valid.
+
+    """
+
+
 @attr.s(hash=True)
 class _FileSystemError(Exception):
 

--- a/filesystems/memory.py
+++ b/filesystems/memory.py
@@ -34,7 +34,7 @@ class _State(object):
         return file
 
     def open_file(self, path, mode):
-        mode = common.normalize_mode(mode)
+        mode = common.parse_mode(mode)
 
         path = self.realpath(path=path)
 

--- a/filesystems/memory.py
+++ b/filesystems/memory.py
@@ -1,5 +1,4 @@
 from io import BytesIO, TextIOWrapper
-import sys
 from uuid import uuid4
 
 from pyrsistent import pmap, pset

--- a/filesystems/memory.py
+++ b/filesystems/memory.py
@@ -33,7 +33,7 @@ class _State(object):
         return file
 
     def open_file(self, path, mode):
-        mode = common.parse_mode(mode)
+        mode = common._parse_mode(mode)
 
         path = self.realpath(path=path)
 

--- a/filesystems/native.py
+++ b/filesystems/native.py
@@ -24,7 +24,7 @@ def _create_file(fs, path):
 
 
 def _open_file(fs, path, mode):
-    mode = common.normalize_mode(mode)
+    mode = common.parse_mode(mode)
 
     try:
         return io.open(str(path), mode.io_open_string())

--- a/filesystems/native.py
+++ b/filesystems/native.py
@@ -1,3 +1,4 @@
+import io
 import os
 import tempfile
 
@@ -19,12 +20,14 @@ def _create_file(fs, path):
             raise exceptions.SymbolicLoop(path.parent())
         raise
 
-    return os.fdopen(fd, "w+b")
+    return io.open(fd, "w+b")
 
 
 def _open_file(fs, path, mode):
+    mode = common.normalize_mode(mode)
+
     try:
-        return open(str(path), mode)
+        return io.open(str(path), mode.io_open_string())
     except (IOError, OSError) as error:
         if error.errno == exceptions.FileNotFound.errno:
             raise exceptions.FileNotFound(path)

--- a/filesystems/native.py
+++ b/filesystems/native.py
@@ -24,7 +24,7 @@ def _create_file(fs, path):
 
 
 def _open_file(fs, path, mode):
-    mode = common.parse_mode(mode)
+    mode = common._parse_mode(mode)
 
     try:
         return io.open(str(path), mode.io_open_string())

--- a/filesystems/tests/common.py
+++ b/filesystems/tests/common.py
@@ -1143,11 +1143,9 @@ class TestFS(object):
         tempdir = fs.temporary_directory()
         self.addCleanup(fs.remove, tempdir)
 
-        def fail():
+        with self.assertRaises(exceptions.InvalidMode):
             with fs.open(tempdir.descendant("unittesting"), mode):
                 pass
-
-        self.assertRaises(exceptions.InvalidMode, fail)
 
     def test_invalid_mode_activity(self):
         self._invalid_mode('z')

--- a/filesystems/tests/common.py
+++ b/filesystems/tests/common.py
@@ -29,7 +29,7 @@ class TestFS(object):
         contents = "some things!"
         if common._PY3:
             b = contents.encode()
-        self._open_file(b=contents, r=contents, mode="r")
+        self._open_file(b=b, r=contents, mode="r")
 
     def open_file_as_text(self):
         contents = u'some things!'

--- a/filesystems/tests/common.py
+++ b/filesystems/tests/common.py
@@ -1144,10 +1144,10 @@ class TestFS(object):
         self.addCleanup(fs.remove, tempdir)
 
         def fail():
-            with fs.open(tempdir.descendant("unittesting", mode)):
+            with fs.open(tempdir.descendant("unittesting"), mode):
                 pass
 
-        self.assertRaises(exceptions.InvalidMode, f=fail)
+        self.assertRaises(exceptions.InvalidMode, fail)
 
     def test_invalid_mode_activity(self):
         self._invalid_mode('z')
@@ -1157,3 +1157,9 @@ class TestFS(object):
 
     def test_invalid_mode_extra(self):
         self._invalid_mode('rbz')
+
+    def test_invalid_mode_binary_and_text(self):
+        self._invalid_mode('rbt')
+
+    def test_invalid_mode_read_and_write(self):
+        self._invalid_mode('rwb')

--- a/filesystems/tests/test_memory.py
+++ b/filesystems/tests/test_memory.py
@@ -1,9 +1,16 @@
 from unittest import TestCase
 
 from pyrsistent import s
+from testscenarios import TestWithScenarios
 
 from filesystems import Path, memory
-from filesystems.tests.common import TestFS
+from filesystems.tests.common import (
+    TestFS,
+    TestInvalidMode,
+    TestOpenFile,
+    TestOpenAppendNonExistingFile,
+    TestWriteLines,
+)
 
 
 class TestMemory(TestFS, TestCase):
@@ -23,3 +30,23 @@ class TestMemory(TestFS, TestCase):
         fs.touch(Path("file"))
         self.assertTrue(fs.exists(Path("file")))
         self.assertFalse(self.FS().exists(Path("file")))
+
+
+class TestMemoryInvalidMode(TestWithScenarios, TestInvalidMode, TestCase):
+    FS = memory.FS
+
+
+class TestMemoryOpenFile(TestWithScenarios, TestOpenFile, TestCase):
+    FS = memory.FS
+
+
+class TestMemoryOpenAppendNonExistingFile(
+    TestWithScenarios,
+    TestOpenAppendNonExistingFile,
+    TestCase,
+):
+    FS = memory.FS
+
+
+class TestMemoryWriteLines(TestWithScenarios, TestWriteLines, TestCase):
+    FS = memory.FS

--- a/filesystems/tests/test_native.py
+++ b/filesystems/tests/test_native.py
@@ -1,8 +1,36 @@
 from unittest import TestCase
 
+from testscenarios import TestWithScenarios
+
 from filesystems import native
-from filesystems.tests.common import TestFS
+from filesystems.tests.common import (
+    TestFS,
+    TestInvalidMode,
+    TestOpenFile,
+    TestOpenAppendNonExistingFile,
+    TestWriteLines,
+)
 
 
 class TestNative(TestFS, TestCase):
+    FS = native.FS
+
+
+class TestNativeInvalidMode(TestWithScenarios, TestInvalidMode, TestCase):
+    FS = native.FS
+
+
+class TestNativeOpenFile(TestWithScenarios, TestOpenFile, TestCase):
+    FS = native.FS
+
+
+class TestNativeOpenAppendNonExistingFile(
+    TestWithScenarios,
+    TestOpenAppendNonExistingFile,
+    TestCase,
+):
+    FS = native.FS
+
+
+class TestNativeWriteLines(TestWithScenarios, TestWriteLines, TestCase):
     FS = native.FS

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ commands =
     {envpython} -m doctest {toxinidir}/README.rst
 deps =
     twisted
+    testscenarios
 
     coverage: coverage
 


### PR DESCRIPTION
I'm not sure if FileMode 'provides a clean interface' or 'is massively over-engineered'...  Also, the 'parametrized' tests are a bit of a change.